### PR TITLE
perf: Change fixed-hash inner hashing and remove unused code

### DIFF
--- a/constructor/src/fixed_hash/core/builtin/std_hash.rs
+++ b/constructor/src/fixed_hash/core/builtin/std_hash.rs
@@ -20,7 +20,7 @@ impl HashConstructor {
             impl ::std::hash::Hash for #name {
                 #[inline]
                 fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
-                    ::std::hash::Hash::hash(&self.inner()[..], state)
+                    state.write(&self.inner()[..])
                 }
             }
         );

--- a/constructor/src/fixed_uint/core/constructor.rs
+++ b/constructor/src/fixed_uint/core/constructor.rs
@@ -58,7 +58,6 @@ pub struct UintTokenStreams {
     pub unit_suffix: TokenStream,
     pub double_unit_suffix: TokenStream,
     pub inner_type: TokenStream,
-    pub bytes_type: TokenStream,
     pub error_name: TokenStream,
     pub utils_name: TokenStream,
 }
@@ -76,7 +75,6 @@ impl<'a> ::std::convert::From<&'a UintInformation> for UintTokenStreams {
         let double_unit_suffix = utils::uint_suffix_to_ts(info.unit_bits_size * 2);
 
         let inner_type = quote!([#unit_suffix; #unit_amount]);
-        let bytes_type = quote!([u8; #bytes_size]);
 
         let error_name = utils::ident_to_ts("FixedUintError");
         let utils_name = utils::ident_to_ts("utils");
@@ -91,7 +89,6 @@ impl<'a> ::std::convert::From<&'a UintInformation> for UintTokenStreams {
             unit_suffix,
             double_unit_suffix,
             inner_type,
-            bytes_type,
             error_name,
             utils_name,
         }


### PR DESCRIPTION
1. Change fixed-hash inner hashing from `slice` to `&[u8]` for better performance.
2. Remove unused code from UintTokenStreams