### PR TITLE
Fix a bug: division is slow in some cases

### DIFF
--- a/constructor/src/fixed_uint/core/internal/private_ops.rs
+++ b/constructor/src/fixed_uint/core/internal/private_ops.rs
@@ -569,6 +569,7 @@ impl UintConstructor {
                     }
                     // below: ret_idx > 0
                     // estimate highest byte of quotient
+                    // could not overflow
                     let divisor = rhs_highest + 1;
                     let dividend = if lhs_highest >= divisor {
                         lhs_highest
@@ -589,9 +590,20 @@ impl UintConstructor {
                         *ret_tmp = tmp;
                         of
                     };
-                    if of {
-                        // `ret[ret_idx + 1] + 1` could not overflow
-                        ret[ret_idx + 1] += 1;
+                    {
+                        let mut ret_idx_tmp = ret_idx + 1;
+                        let mut ret_of = of;
+                        loop {
+                            if ret_of {
+                                let ret_tmp = &mut ret[ret_idx_tmp];
+                                let (tmp, of) = ret_tmp.overflowing_add(1);
+                                *ret_tmp = tmp;
+                                ret_of = of;
+                                ret_idx_tmp += 1;
+                            } else {
+                                break;
+                            }
+                        }
                     }
                     let minuend = {
                         // could not overflow

--- a/fixed-uint-tests/tests/regression_tests.rs
+++ b/fixed-uint-tests/tests/regression_tests.rs
@@ -19,3 +19,19 @@ fn div_throw_add_overflow() {
     let z = ((nfuint::U256::one() << 255) / &y) << 1;
     assert_eq!(x, z);
 }
+
+#[test]
+fn div_too_slow() {
+    let x =
+        nfuint::U4096::from_hex_str("272184cdaf3736f0fa54c1d8529a9294bcc2ac0b180838228ab").unwrap();
+    let y = nfuint::U4096::from_hex_str(
+        "8000000000000000000000000000000000000000000000000000000000000000",
+    )
+    .unwrap();
+    let expected = nfuint::U4096::from_hex_str(
+        "6b851a863a5e38d58e175cb90a7b4dd5b7bcab518f09f17ade7398cc5621e239",
+    )
+    .unwrap();
+    let result = &x * &x % y;
+    assert_eq!(expected, result);
+}

--- a/fixed-uint-tests/tests/regression_tests.rs
+++ b/fixed-uint-tests/tests/regression_tests.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 #[test]
-fn div_throw_add_overflow() {
+fn div_throw_add_overflow_1() {
     let one = nfuint::U256::one();
     for i in 0..255 {
         let x = nfuint::U256::one() << i;
@@ -18,6 +18,24 @@ fn div_throw_add_overflow() {
     let y = ((nfuint::U256::one() << 255) / &x) << 1;
     let z = ((nfuint::U256::one() << 255) / &y) << 1;
     assert_eq!(x, z);
+}
+
+#[test]
+fn div_throw_add_overflow_2() {
+    let x = nfuint::U4096::from_hex_str(
+        "aab1deb8c8a4ba3d000000000000000000000000000000000000000000000001",
+    )
+    .unwrap();
+    let y = nfuint::U4096::from_hex_str(
+        "10000000000000000000000000000000000000000000000000000000000000000",
+    )
+    .unwrap();
+    let expected = nfuint::U4096::from_hex_str(
+        "5563bd719149747a000000000000000000000000000000000000000000000001",
+    )
+    .unwrap();
+    let result = &x * &x % y;
+    assert_eq!(result, expected);
 }
 
 #[test]
@@ -33,5 +51,5 @@ fn div_too_slow() {
     )
     .unwrap();
     let result = &x * &x % y;
-    assert_eq!(expected, result);
+    assert_eq!(result, expected);
 }


### PR DESCRIPTION
- [x] Fix bug: in division, when borrow a higher unit, do not forget check if the higher unit was reduced to zero after subtraction.

  The reason was written in [this comment](https://github.com/cryptape/rust-numext/issues/34#issuecomment-476687930).

- [x] Fix bug: in division, when doing estimate is too cautious, so the estimated quotient is too small each time, led to an overflow.

  The reason was written in [this comment](https://github.com/cryptape/rust-numext/issues/36#issuecomment-476944558).