### PR TITLE
Export errors in the main crates.

### DIFF
--- a/fixed-hash-tests/tests/errors.rs
+++ b/fixed-hash-tests/tests/errors.rs
@@ -1,0 +1,46 @@
+// Copyright 2018-2019 Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use nfhash::H128;
+use nfhash::{FixedHashError, FromSliceError, FromStrError, IntoSliceError};
+use std::str::FromStr;
+
+#[test]
+fn errors() {
+    {
+        let input = [0u8; 15];
+        let err = H128::from_slice(&input);
+        if let Err(FixedHashError::FromSlice(FromSliceError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `FromSliceError::InvalidLength`");
+        }
+    }
+    {
+        let mut input = [0u8; 17];
+        let hash = H128::zero();
+        let err = hash.into_slice(&mut input);
+        if let Err(FixedHashError::IntoSlice(IntoSliceError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `IntoSliceError::InvalidLength`");
+        }
+    }
+    {
+        let err = H128::from_trimmed_hex_str("z");
+        if let Err(FixedHashError::FromStr(FromStrError::InvalidCharacter { .. })) = err {
+        } else {
+            panic!("this error should be `FromStrError::InvalidCharacter`");
+        }
+    }
+    {
+        let err = H128::from_str("a");
+        if let Err(FixedHashError::FromStr(FromStrError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `FromStrError::InvalidLength`");
+        }
+    }
+}

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -38,6 +38,7 @@
 use proc_macro_hack::proc_macro_hack;
 
 pub use numext_fixed_hash_core::prelude;
+pub use numext_fixed_hash_core::{FixedHashError, FromSliceError, FromStrError, IntoSliceError};
 
 macro_rules! reexport {
     ([$(($name:ident, $macro_name:ident),)+]) => {

--- a/fixed-uint-tests/tests/errors.rs
+++ b/fixed-uint-tests/tests/errors.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2019 Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use nfuint::{FixedUintError, FromSliceError, FromStrError, IntoSliceError};
+use nfuint::{U128, U256};
+
+#[test]
+fn errors() {
+    {
+        let input = [0u8; 17];
+        let err = U128::from_little_endian(&input);
+        if let Err(FixedUintError::FromSlice(FromSliceError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `FromSliceError::InvalidLength`");
+        }
+    }
+    {
+        let mut input = [0u8; 17];
+        let uint = U128::zero();
+        let err = uint.into_little_endian(&mut input);
+        if let Err(FixedUintError::IntoSlice(IntoSliceError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `IntoSliceError::InvalidLength`");
+        }
+    }
+    {
+        let err = U128::from_hex_str("z");
+        if let Err(FixedUintError::FromStr(FromStrError::InvalidCharacter { .. })) = err {
+        } else {
+            panic!("this error should be `FromStrError::InvalidCharacter`");
+        }
+    }
+    {
+        let err = U128::from_hex_str("");
+        if let Err(FixedUintError::FromStr(FromStrError::InvalidLength(_))) = err {
+        } else {
+            panic!("this error should be `FromStrError::InvalidLength`");
+        }
+    }
+    {
+        let uint = U256::one() << 128;
+        let uint_str = format!("{}", uint);
+        let err = U128::from_dec_str(&uint_str);
+        if let Err(FixedUintError::FromStr(FromStrError::Overflow(_))) = err {
+        } else {
+            panic!("this error should be `FromStrError::Overflow`");
+        }
+    }
+}

--- a/fixed-uint/src/lib.rs
+++ b/fixed-uint/src/lib.rs
@@ -43,6 +43,7 @@
 use proc_macro_hack::proc_macro_hack;
 
 pub use numext_fixed_uint_core::prelude;
+pub use numext_fixed_uint_core::{FixedUintError, FromSliceError, FromStrError, IntoSliceError};
 
 macro_rules! reexport {
     ([$(($name:ident, $macro_name:ident),)+]) => {


### PR DESCRIPTION
Fix: the errors are only can be imported from the `*-core` crates.
And add checks into CI.