### PR TITLE
fix: few bugs

### DIFF
--- a/constructor/src/fixed_hash/core/constructor.rs
+++ b/constructor/src/fixed_hash/core/constructor.rs
@@ -158,7 +158,7 @@ impl HashConstructor {
             } else {
                 let utils = TokenStream::from_iter(utils);
                 quote!(
-                    pub mod #utils_name {
+                    pub(crate) mod #utils_name {
                         #utils
                     }
                 )

--- a/constructor/src/fixed_hash/core/internal/public_basic.rs
+++ b/constructor/src/fixed_hash/core/internal/public_basic.rs
@@ -184,7 +184,7 @@ impl HashConstructor {
             }
             /// Get the mutable inner bytes of a fixed hash.
             #[inline]
-            pub fn as_fixed_bytes_mut(&mut self) -> &#inner_type {
+            pub fn as_fixed_bytes_mut(&mut self) -> &mut #inner_type {
                 self.mut_inner()
             }
             /// Get the inner bytes array of a fixed hash.

--- a/constructor/src/fixed_uint/core/constructor.rs
+++ b/constructor/src/fixed_uint/core/constructor.rs
@@ -181,7 +181,7 @@ impl UintConstructor {
             } else {
                 let utils = TokenStream::from_iter(utils);
                 quote!(
-                    pub mod #utils_name {
+                    pub(crate) mod #utils_name {
                         #utils
                     }
                 )

--- a/fixed-hash-tests/tests/constructor.rs
+++ b/fixed-hash-tests/tests/constructor.rs
@@ -9,10 +9,12 @@
 use nfhash::{h128, h4096, H128, H4096};
 use std::str::FromStr;
 
+const H128_ZERO: H128 = h128!("0x0");
 const H64MAX: H4096 = h4096!("0x_ffff_ffff_ffff_ffff");
 
 #[test]
 fn constructor() {
+    assert_eq!(H128_ZERO, H128::zero());
     {
         let x1 = h128!("0x123456789abcdef");
         let x2 = h128!("0x00000000000000000123456789abcdef");

--- a/fixed-hash/hack/src/lib.rs
+++ b/fixed-hash/hack/src/lib.rs
@@ -34,13 +34,17 @@ macro_rules! impl_hack {
             let input = parse_macro_input!(input as syn::LitStr);
             let expanded = {
                 let input = input.value().replace("_", "");
-                if &input[..2] != "0x" {
+                if input.len() < 3 || &input[..2] != "0x" {
                     panic!("Input has to be a hexadecimal string with 0x-prefix.");
                 };
                 let input_str = &input[2..];
                 let value = match &input_str[..1] {
                     "0" => {
-                        nfhash::$type::from_hex_str(input_str)
+                        if input_str.len() > 1 {
+                            nfhash::$type::from_hex_str(input_str)
+                        } else {
+                            nfhash::$type::from_trimmed_hex_str(input_str)
+                        }
                     },
                     _ => {
                         nfhash::$type::from_trimmed_hex_str(input_str)

--- a/fixed-uint-tests/tests/constructor.rs
+++ b/fixed-uint-tests/tests/constructor.rs
@@ -8,10 +8,12 @@
 
 use nfuint::{u128, u256, u4096, U128, U256, U4096};
 
+const U128_ZERO: U128 = u128!("0");
 const U128_100: U128 = u128!("100");
 
 #[test]
 fn constructor() {
+    assert_eq!(U128_ZERO, U128::zero());
     {
         let x1 = u128!("0b110_0100");
         let x2 = u128!("0o144");

--- a/fixed-uint/hack/src/lib.rs
+++ b/fixed-uint/hack/src/lib.rs
@@ -34,11 +34,18 @@ macro_rules! impl_hack {
             let input = parse_macro_input!(input as syn::LitStr);
             let expanded = {
                 let input = input.value().replace("_", "");
-                let (value_result, input_type) = match &input[..2] {
-                    "0b" => (nfuint::$type::from_bin_str(&input[2..]), "binary"),
-                    "0o" => (nfuint::$type::from_oct_str(&input[2..]), "octal"),
-                    "0x" => (nfuint::$type::from_hex_str(&input[2..]), "hexadecimal"),
-                    _ => (nfuint::$type::from_dec_str(&input), "decimal"),
+                if input.is_empty() {
+                    panic!("Input is empty.");
+                }
+                let (value_result, input_type) = if input.len() < 3 {
+                    (nfuint::$type::from_dec_str(&input), "decimal")
+                } else {
+                    match &input[..2] {
+                        "0b" => (nfuint::$type::from_bin_str(&input[2..]), "binary"),
+                        "0o" => (nfuint::$type::from_oct_str(&input[2..]), "octal"),
+                        "0x" => (nfuint::$type::from_hex_str(&input[2..]), "hexadecimal"),
+                        _ => (nfuint::$type::from_dec_str(&input), "decimal"),
+                    }
                 };
                 let value = value_result.unwrap_or_else(|err| {
                     panic!("Failed to parse the input {} string: {}", input_type, err);


### PR DESCRIPTION
- fix: constructors can not handle short inputs correctly

  Such as `h256!("0x0")`, `u128!("0")`, will cause panics.

- fix: `as_fixed_bytes_mut(&mut self)` return an immutable reference

  https://github.com/cryptape/rust-numext/blob/33990f62c7c1558d0e8aacb4bfc461e60d6e53dc/constructor/src/fixed_hash/core/internal/public_basic.rs#L185-L189

- docs: remove documentation for empty modules