### PR TITLE
feat: use features to let all structs be optional

### DIFF
--- a/constructor/src/fixed_hash/core/internal/kernel.rs
+++ b/constructor/src/fixed_hash/core/internal/kernel.rs
@@ -22,7 +22,9 @@ impl HashConstructor {
 
     pub fn convert_into(&self, uc: &Self) -> TokenStream {
         let this_name = &self.ts.name;
+        let this_feature = &self.ts.feature;
         let that_name = &uc.ts.name;
+        let that_feature = &uc.ts.feature;
         let stmts = if self.info.bits_size == uc.info.bits_size {
             quote!(
                 let inner = self.inner();
@@ -46,6 +48,7 @@ impl HashConstructor {
             )
         };
         quote!(
+            #[cfg(all(feature = #this_feature, feature = #that_feature))]
             impl prelude::HashConvert<#that_name> for #this_name {
                 #[inline]
                 fn convert_into(&self) -> (#that_name, bool) {
@@ -66,17 +69,17 @@ impl HashConstructor {
             }
             /// Get a reference of the inner data of the fixed hash.
             #[inline]
-            fn inner<'a>(&'a self) -> &'a #inner_type {
+            pub(crate) fn inner<'a>(&'a self) -> &'a #inner_type {
                 &self.0
             }
             /// Get a mutable reference of the inner data of the fixed hash.
             #[inline]
-            fn mut_inner<'a>(&'a mut self) -> &'a mut #inner_type {
+            pub(crate) fn mut_inner<'a>(&'a mut self) -> &'a mut #inner_type {
                 &mut self.0
             }
             /// Get the inner data of the fixed hash.
             #[inline]
-            fn into_inner(self) -> #inner_type {
+            pub(crate) fn into_inner(self) -> #inner_type {
                 self.0
             }
         );

--- a/constructor/src/fixed_uint/core/internal/kernel.rs
+++ b/constructor/src/fixed_uint/core/internal/kernel.rs
@@ -22,7 +22,9 @@ impl UintConstructor {
 
     pub fn convert_into(&self, uc: &Self) -> TokenStream {
         let this_name = &self.ts.name;
+        let this_feature = &self.ts.feature;
         let that_name = &uc.ts.name;
+        let that_feature = &uc.ts.feature;
         let stmts = if self.info.bits_size == uc.info.bits_size {
             if self.info.unit_bits_size == uc.info.unit_bits_size {
                 // same inner
@@ -76,6 +78,7 @@ impl UintConstructor {
             )
         };
         quote!(
+            #[cfg(all(feature = #this_feature, feature = #that_feature))]
             impl prelude::UintConvert<#that_name> for #this_name {
                 #[inline]
                 fn convert_into(&self) -> (#that_name, bool) {
@@ -96,17 +99,17 @@ impl UintConstructor {
             }
             /// Get a reference of the inner data of the fixed uint.
             #[inline]
-            fn inner<'a>(&'a self) -> &'a #inner_type {
+            pub(crate) fn inner<'a>(&'a self) -> &'a #inner_type {
                 &self.0
             }
             /// Get a mutable reference of the inner data of the fixed uint.
             #[inline]
-            fn mut_inner<'a>(&'a mut self) -> &'a mut #inner_type {
+            pub(crate) fn mut_inner<'a>(&'a mut self) -> &'a mut #inner_type {
                 &mut self.0
             }
             /// Get the inner data of the fixed uint.
             #[inline]
-            fn into_inner(self) -> #inner_type {
+            pub(crate) fn into_inner(self) -> #inner_type {
                 self.0
             }
         );

--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -11,16 +11,30 @@ categories = ["algorithms", "data-structures"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-numext-fixed-hash-core = { version = "=0.1.4", path = "core" }
-numext-fixed-hash-hack = { version = "=0.1.4", path = "hack" }
+nfhash-core = { package = "numext-fixed-hash-core", version = "=0.1.4", path = "core" }
+nfhash-hack = { package = "numext-fixed-hash-hack", version = "=0.1.4", path = "hack" }
 proc-macro-hack = "~0.5"
 
 [features]
-default = []
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
 support_all = ["support_rand", "support_heapsize", "support_serde"]
-support_rand = ["numext-fixed-hash-core/support_rand", "numext-fixed-hash-hack/support_rand"]
-support_heapsize = ["numext-fixed-hash-core/support_heapsize", "numext-fixed-hash-hack/support_heapsize"]
-support_serde = ["numext-fixed-hash-core/support_serde", "numext-fixed-hash-hack/support_serde"]
+bits_128 =  ["nfhash-core/bits_128" , "nfhash-hack/bits_128" ]
+bits_160 =  ["nfhash-core/bits_160" , "nfhash-hack/bits_160" ]
+bits_224 =  ["nfhash-core/bits_224" , "nfhash-hack/bits_224" ]
+bits_256 =  ["nfhash-core/bits_256" , "nfhash-hack/bits_256" ]
+bits_384 =  ["nfhash-core/bits_384" , "nfhash-hack/bits_384" ]
+bits_512 =  ["nfhash-core/bits_512" , "nfhash-hack/bits_512" ]
+bits_520 =  ["nfhash-core/bits_520" , "nfhash-hack/bits_520" ]
+bits_1024 = ["nfhash-core/bits_1024", "nfhash-hack/bits_1024"]
+bits_2048 = ["nfhash-core/bits_2048", "nfhash-hack/bits_2048"]
+bits_4096 = ["nfhash-core/bits_4096", "nfhash-hack/bits_4096"]
+support_rand     = ["nfhash-core/support_rand"    , "nfhash-hack/support_rand"    ]
+support_heapsize = ["nfhash-core/support_heapsize", "nfhash-hack/support_heapsize"]
+support_serde    = ["nfhash-core/support_serde"   , "nfhash-hack/support_serde"   ]
 
 [badges]
 travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-hash/core/Cargo.toml
+++ b/fixed-hash/core/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["algorithms", "data-structures"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-numext-constructor = { version = "=0.1.4", path = "../../constructor" }
-numext-fixed-uint = { version = "=0.1.4", path = "../../fixed-uint" }
+constructor = { package = "numext-constructor", version = "=0.1.4", path = "../../constructor" }
+nfuint = { package = "numext-fixed-uint", version = "=0.1.4", path = "../../fixed-uint" }
 failure = "~0.1"
 rand = { version = "~0.5", optional = true }
 heapsize = { version = "~0.4", optional = true }
@@ -20,8 +20,25 @@ serde = { version = "~1.0", optional = true }
 faster-hex = { version = "~0.1", optional = true }
 
 [features]
-default = []
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
 support_all = ["support_rand", "support_heapsize", "support_serde"]
-support_rand = ["rand", "numext-fixed-uint/support_rand"]
-support_heapsize = ["heapsize", "numext-fixed-uint/support_heapsize"]
-support_serde = ["serde", "faster-hex", "numext-fixed-uint/support_serde"]
+bits_128 =  ["nfuint/bits_128" ]
+bits_160 =  ["nfuint/bits_160" ]
+bits_224 =  ["nfuint/bits_224" ]
+bits_256 =  ["nfuint/bits_256" ]
+bits_384 =  ["nfuint/bits_384" ]
+bits_512 =  ["nfuint/bits_512" ]
+bits_520 =  ["nfuint/bits_520" ]
+bits_1024 = ["nfuint/bits_1024"]
+bits_2048 = ["nfuint/bits_2048"]
+bits_4096 = ["nfuint/bits_4096"]
+support_rand     = ["rand",     "nfuint/support_rand"    ]
+support_heapsize = ["heapsize", "nfuint/support_heapsize"]
+support_serde    = ["serde",    "nfuint/support_serde"   , "faster-hex"]
+
+[badges]
+travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-hash/core/src/lib.rs
+++ b/fixed-hash/core/src/lib.rs
@@ -19,7 +19,7 @@ use failure::Fail;
 #[macro_use]
 mod tools;
 
-numext_constructor::construct_fixed_hashes!(
+constructor::construct_fixed_hashes!(
     H128 {
         size = 128,
     },
@@ -52,12 +52,23 @@ numext_constructor::construct_fixed_hashes!(
     },
 );
 
+#[cfg(feature = "bits_128")]
 convert_between!(U128, H128, 16);
+#[cfg(feature = "bits_160")]
 convert_between!(U160, H160, 20);
+#[cfg(feature = "bits_224")]
 convert_between!(U224, H224, 28);
+#[cfg(feature = "bits_256")]
 convert_between!(U256, H256, 32);
+#[cfg(feature = "bits_384")]
 convert_between!(U384, H384, 48);
+#[cfg(feature = "bits_512")]
 convert_between!(U512, H512, 64);
+#[cfg(feature = "bits_520")]
+convert_between!(U520, H520, 65);
+#[cfg(feature = "bits_1024")]
 convert_between!(U1024, H1024, 128);
+#[cfg(feature = "bits_2048")]
 convert_between!(U2048, H2048, 256);
+#[cfg(feature = "bits_4096")]
 convert_between!(U4096, H4096, 512);

--- a/fixed-hash/core/src/tools.rs
+++ b/fixed-hash/core/src/tools.rs
@@ -8,9 +8,9 @@
 
 macro_rules! convert_between {
     ($uint:ident, $hash:ident, $bytes_size:expr) => {
-        impl<'a> From<&'a numext_fixed_uint::$uint> for $hash {
+        impl<'a> From<&'a nfuint::$uint> for $hash {
             #[inline]
-            fn from(u: &numext_fixed_uint::$uint) -> Self {
+            fn from(u: &nfuint::$uint) -> Self {
                 let mut ret = [0u8; $bytes_size];
                 u.into_big_endian(&mut ret).unwrap_or_else(|e| {
                     panic!(
@@ -23,16 +23,16 @@ macro_rules! convert_between {
                 ret.into()
             }
         }
-        impl From<numext_fixed_uint::$uint> for $hash {
+        impl From<nfuint::$uint> for $hash {
             #[inline]
-            fn from(u: numext_fixed_uint::$uint) -> Self {
+            fn from(u: nfuint::$uint) -> Self {
                 (&u).into()
             }
         }
-        impl<'a> From<&'a $hash> for numext_fixed_uint::$uint {
+        impl<'a> From<&'a $hash> for nfuint::$uint {
             #[inline]
             fn from(h: &$hash) -> Self {
-                numext_fixed_uint::$uint::from_big_endian(h.as_bytes()).unwrap_or_else(|e| {
+                nfuint::$uint::from_big_endian(h.as_bytes()).unwrap_or_else(|e| {
                     panic!(
                         "failed to convert from {} to {}: {}",
                         stringify!($hash),
@@ -42,7 +42,7 @@ macro_rules! convert_between {
                 })
             }
         }
-        impl From<$hash> for numext_fixed_uint::$uint {
+        impl From<$hash> for nfuint::$uint {
             #[inline]
             fn from(h: $hash) -> Self {
                 (&h).into()

--- a/fixed-hash/hack/Cargo.toml
+++ b/fixed-hash/hack/Cargo.toml
@@ -14,14 +14,32 @@ license = "Apache-2.0 OR MIT"
 proc-macro = true
 
 [dependencies]
-numext-fixed-hash-core = { version = "=0.1.4", path = "../core" }
+nfhash-core = { package = "numext-fixed-hash-core", version = "=0.1.4", path = "../core" }
 proc-macro-hack = "~0.5"
 syn = { version = "~0.15", features = ["extra-traits"] }
 quote = "~0.6"
 proc-macro2 = "~0.4"
 
 [features]
-default = []
-support_rand = ["numext-fixed-hash-core/support_rand"]
-support_heapsize = ["numext-fixed-hash-core/support_heapsize"]
-support_serde = ["numext-fixed-hash-core/support_serde"]
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
+support_all = ["support_rand", "support_heapsize", "support_serde"]
+bits_128 =  ["nfhash-core/bits_128" ]
+bits_160 =  ["nfhash-core/bits_160" ]
+bits_224 =  ["nfhash-core/bits_224" ]
+bits_256 =  ["nfhash-core/bits_256" ]
+bits_384 =  ["nfhash-core/bits_384" ]
+bits_512 =  ["nfhash-core/bits_512" ]
+bits_520 =  ["nfhash-core/bits_520" ]
+bits_1024 = ["nfhash-core/bits_1024"]
+bits_2048 = ["nfhash-core/bits_2048"]
+bits_4096 = ["nfhash-core/bits_4096"]
+support_rand     = ["nfhash-core/support_rand"    ]
+support_heapsize = ["nfhash-core/support_heapsize"]
+support_serde    = ["nfhash-core/support_serde"   ]
+
+[badges]
+travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-hash/hack/src/lib.rs
+++ b/fixed-hash/hack/src/lib.rs
@@ -16,18 +16,11 @@
 
 extern crate proc_macro;
 
-use numext_fixed_hash_core as nfhash;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse_macro_input;
 
 macro_rules! impl_hack {
-    ($(($name:ident, $type:ident),)+) => {
-        $(impl_hack!($name, $type);)+
-    };
-    ($(($name:ident, $type:ident)),+) => {
-        $(impl_hack!($name, $type);)+
-    };
     ($name:ident, $type:ident) =>    {
         #[proc_macro_hack]
         pub fn $name(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -41,13 +34,13 @@ macro_rules! impl_hack {
                 let value = match &input_str[..1] {
                     "0" => {
                         if input_str.len() > 1 {
-                            nfhash::$type::from_hex_str(input_str)
+                            nfhash_core::$type::from_hex_str(input_str)
                         } else {
-                            nfhash::$type::from_trimmed_hex_str(input_str)
+                            nfhash_core::$type::from_trimmed_hex_str(input_str)
                         }
                     },
                     _ => {
-                        nfhash::$type::from_trimmed_hex_str(input_str)
+                        nfhash_core::$type::from_trimmed_hex_str(input_str)
                     },
                 }
                 .unwrap_or_else(|err| {
@@ -64,15 +57,23 @@ macro_rules! impl_hack {
     };
 }
 
-impl_hack!(
-    (h128, H128),
-    (h160, H160),
-    (h224, H224),
-    (h256, H256),
-    (h384, H384),
-    (h512, H512),
-    (h520, H520),
-    (h1024, H1024),
-    (h2048, H2048),
-    (h4096, H4096),
-);
+#[cfg(feature = "bits_128")]
+impl_hack!(h128, H128);
+#[cfg(feature = "bits_160")]
+impl_hack!(h160, H160);
+#[cfg(feature = "bits_224")]
+impl_hack!(h224, H224);
+#[cfg(feature = "bits_256")]
+impl_hack!(h256, H256);
+#[cfg(feature = "bits_384")]
+impl_hack!(h384, H384);
+#[cfg(feature = "bits_512")]
+impl_hack!(h512, H512);
+#[cfg(feature = "bits_520")]
+impl_hack!(h520, H520);
+#[cfg(feature = "bits_1024")]
+impl_hack!(h1024, H1024);
+#[cfg(feature = "bits_2048")]
+impl_hack!(h2048, H2048);
+#[cfg(feature = "bits_4096")]
+impl_hack!(h4096, H4096);

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -37,33 +37,35 @@
 
 use proc_macro_hack::proc_macro_hack;
 
-pub use numext_fixed_hash_core::prelude;
-pub use numext_fixed_hash_core::{FixedHashError, FromSliceError, FromStrError, IntoSliceError};
+pub use nfhash_core::prelude;
+pub use nfhash_core::{FixedHashError, FromSliceError, FromStrError, IntoSliceError};
 
 macro_rules! reexport {
-    ([$(($name:ident, $macro_name:ident),)+]) => {
-        $(reexport!($name, $macro_name);)+
-    };
-    ([$(($name:ident, $macro_name:ident)),+]) => {
-        $(reexport!($name, $macro_name);)+
-    };
-    ($name:ident, $macro_name:ident) =>    {
-        pub use numext_fixed_hash_core::$name;
+    ($name:ident, $macro_name:ident) => {
+        pub use nfhash_core::$name;
         /// A macro used to construct a fixed hash in compile time.
         #[proc_macro_hack]
-        pub use numext_fixed_hash_hack::$macro_name;
+        pub use nfhash_hack::$macro_name;
     };
 }
 
-reexport!([
-    (H128, h128),
-    (H160, h160),
-    (H224, h224),
-    (H256, h256),
-    (H384, h384),
-    (H512, h512),
-    (H520, h520),
-    (H1024, h1024),
-    (H2048, h2048),
-    (H4096, h4096),
-]);
+#[cfg(feature = "bits_128")]
+reexport!(H128, h128);
+#[cfg(feature = "bits_160")]
+reexport!(H160, h160);
+#[cfg(feature = "bits_224")]
+reexport!(H224, h224);
+#[cfg(feature = "bits_256")]
+reexport!(H256, h256);
+#[cfg(feature = "bits_384")]
+reexport!(H384, h384);
+#[cfg(feature = "bits_512")]
+reexport!(H512, h512);
+#[cfg(feature = "bits_520")]
+reexport!(H520, h520);
+#[cfg(feature = "bits_1024")]
+reexport!(H1024, h1024);
+#[cfg(feature = "bits_2048")]
+reexport!(H2048, h2048);
+#[cfg(feature = "bits_4096")]
+reexport!(H4096, h4096);

--- a/fixed-uint/Cargo.toml
+++ b/fixed-uint/Cargo.toml
@@ -11,16 +11,30 @@ categories = ["algorithms", "data-structures"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-numext-fixed-uint-core = { version = "=0.1.4", path = "core" }
-numext-fixed-uint-hack = { version = "=0.1.4", path = "hack" }
+nfuint-core = { package ="numext-fixed-uint-core", version = "=0.1.4", path = "core" }
+nfuint-hack = { package ="numext-fixed-uint-hack", version = "=0.1.4", path = "hack" }
 proc-macro-hack = "~0.5"
 
 [features]
-default = []
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
 support_all = ["support_rand", "support_heapsize", "support_serde"]
-support_rand = ["numext-fixed-uint-core/support_rand", "numext-fixed-uint-hack/support_rand"]
-support_heapsize = ["numext-fixed-uint-core/support_heapsize", "numext-fixed-uint-hack/support_heapsize"]
-support_serde = ["numext-fixed-uint-core/support_serde", "numext-fixed-uint-hack/support_serde"]
+bits_128 =  ["nfuint-core/bits_128" , "nfuint-hack/bits_128" ]
+bits_160 =  ["nfuint-core/bits_160" , "nfuint-hack/bits_160" ]
+bits_224 =  ["nfuint-core/bits_224" , "nfuint-hack/bits_224" ]
+bits_256 =  ["nfuint-core/bits_256" , "nfuint-hack/bits_256" ]
+bits_384 =  ["nfuint-core/bits_384" , "nfuint-hack/bits_384" ]
+bits_512 =  ["nfuint-core/bits_512" , "nfuint-hack/bits_512" ]
+bits_520 =  ["nfuint-core/bits_520" , "nfuint-hack/bits_520" ]
+bits_1024 = ["nfuint-core/bits_1024", "nfuint-hack/bits_1024"]
+bits_2048 = ["nfuint-core/bits_2048", "nfuint-hack/bits_2048"]
+bits_4096 = ["nfuint-core/bits_4096", "nfuint-hack/bits_4096"]
+support_rand     = ["nfuint-core/support_rand"    , "nfuint-hack/support_rand"    ]
+support_heapsize = ["nfuint-core/support_heapsize", "nfuint-hack/support_heapsize"]
+support_serde    = ["nfuint-core/support_serde"   , "nfuint-hack/support_serde"   ]
 
 [badges]
 travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-uint/core/Cargo.toml
+++ b/fixed-uint/core/Cargo.toml
@@ -12,14 +12,32 @@ license = "Apache-2.0 OR MIT"
 
 
 [dependencies]
-numext-constructor = { version = "=0.1.4", path = "../../constructor" }
+constructor = { package = "numext-constructor", version = "=0.1.4", path = "../../constructor" }
 failure = "~0.1"
 rand = { version = "~0.5", optional = true }
 heapsize = { version = "~0.4", optional = true }
 serde = { version = "~1.0", optional = true }
 
 [features]
-default = []
-support_rand = ["rand"]
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
+support_all = ["support_rand", "support_heapsize", "support_serde"]
+bits_128 =  []
+bits_160 =  []
+bits_224 =  []
+bits_256 =  []
+bits_384 =  []
+bits_512 =  []
+bits_520 =  []
+bits_1024 = []
+bits_2048 = []
+bits_4096 = []
+support_rand     = ["rand"    ]
 support_heapsize = ["heapsize"]
-support_serde = ["serde"]
+support_serde    = ["serde"   ]
+
+[badges]
+travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-uint/core/src/lib.rs
+++ b/fixed-uint/core/src/lib.rs
@@ -16,7 +16,7 @@
 
 use failure::Fail;
 
-numext_constructor::construct_fixed_uints!(
+constructor::construct_fixed_uints!(
     U128 {
         size = 128,
     },

--- a/fixed-uint/hack/Cargo.toml
+++ b/fixed-uint/hack/Cargo.toml
@@ -14,14 +14,32 @@ license = "Apache-2.0 OR MIT"
 proc-macro = true
 
 [dependencies]
-numext-fixed-uint-core = { version = "=0.1.4", path = "../core" }
+nfuint-core = { package = "numext-fixed-uint-core", version = "=0.1.4", path = "../core" }
 proc-macro-hack = "~0.5"
 syn = { version = "~0.15", features = ["extra-traits"] }
 quote = "~0.6"
 proc-macro2 = "~0.4"
 
 [features]
-default = []
-support_rand = ["numext-fixed-uint-core/support_rand"]
-support_heapsize = ["numext-fixed-uint-core/support_heapsize"]
-support_serde = ["numext-fixed-uint-core/support_serde"]
+default = ["bits_all"]
+bits_all = [
+    "bits_128", "bits_160", "bits_224", "bits_256", "bits_384", "bits_512",
+    "bits_520", "bits_1024",  "bits_2048", "bits_4096",
+]
+support_all = ["support_rand", "support_heapsize", "support_serde"]
+bits_128 =  ["nfuint-core/bits_128" ]
+bits_160 =  ["nfuint-core/bits_160" ]
+bits_224 =  ["nfuint-core/bits_224" ]
+bits_256 =  ["nfuint-core/bits_256" ]
+bits_384 =  ["nfuint-core/bits_384" ]
+bits_512 =  ["nfuint-core/bits_512" ]
+bits_520 =  ["nfuint-core/bits_520" ]
+bits_1024 = ["nfuint-core/bits_1024"]
+bits_2048 = ["nfuint-core/bits_2048"]
+bits_4096 = ["nfuint-core/bits_4096"]
+support_rand     = ["nfuint-core/support_rand"    ]
+support_heapsize = ["nfuint-core/support_heapsize"]
+support_serde    = ["nfuint-core/support_serde"   ]
+
+[badges]
+travis-ci = { repository = "cryptape/rust-numext" }

--- a/fixed-uint/hack/src/lib.rs
+++ b/fixed-uint/hack/src/lib.rs
@@ -16,7 +16,6 @@
 
 extern crate proc_macro;
 
-use numext_fixed_uint_core as nfuint;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse_macro_input;
@@ -38,13 +37,13 @@ macro_rules! impl_hack {
                     panic!("Input is empty.");
                 }
                 let (value_result, input_type) = if input.len() < 3 {
-                    (nfuint::$type::from_dec_str(&input), "decimal")
+                    (nfuint_core::$type::from_dec_str(&input), "decimal")
                 } else {
                     match &input[..2] {
-                        "0b" => (nfuint::$type::from_bin_str(&input[2..]), "binary"),
-                        "0o" => (nfuint::$type::from_oct_str(&input[2..]), "octal"),
-                        "0x" => (nfuint::$type::from_hex_str(&input[2..]), "hexadecimal"),
-                        _ => (nfuint::$type::from_dec_str(&input), "decimal"),
+                        "0b" => (nfuint_core::$type::from_bin_str(&input[2..]), "binary"),
+                        "0o" => (nfuint_core::$type::from_oct_str(&input[2..]), "octal"),
+                        "0x" => (nfuint_core::$type::from_hex_str(&input[2..]), "hexadecimal"),
+                        _ => (nfuint_core::$type::from_dec_str(&input), "decimal"),
                     }
                 };
                 let value = value_result.unwrap_or_else(|err| {

--- a/fixed-uint/src/lib.rs
+++ b/fixed-uint/src/lib.rs
@@ -42,8 +42,8 @@
 
 use proc_macro_hack::proc_macro_hack;
 
-pub use numext_fixed_uint_core::prelude;
-pub use numext_fixed_uint_core::{FixedUintError, FromSliceError, FromStrError, IntoSliceError};
+pub use nfuint_core::prelude;
+pub use nfuint_core::{FixedUintError, FromSliceError, FromStrError, IntoSliceError};
 
 macro_rules! reexport {
     ([$(($name:ident, $macro_name:ident),)+]) => {
@@ -53,10 +53,10 @@ macro_rules! reexport {
         $(reexport!($name, $macro_name);)+
     };
     ($name:ident, $macro_name:ident) =>    {
-        pub use numext_fixed_uint_core::$name;
+        pub use nfuint_core::$name;
         /// A macro used to construct a fixed uint in compile time.
         #[proc_macro_hack]
-        pub use numext_fixed_uint_hack::$macro_name;
+        pub use nfuint_hack::$macro_name;
     };
 }
 


### PR DESCRIPTION
### Notice

:disappointed: **After several tests, I think select few hashes doesn't reduce compile time.**

### Examples

Before merge this PR, you can try it from my repository:

- Need all Hashes (`bits_all` is the `default-features`):

   ```toml
   [dependencies.numext-fixed-hash]
   git = "https://github.com/yangby-cryptape/rust-numext"
   branch = "optional-structs"
   ```

- Only need `H256` and `H512`.

  ```toml
  [dependencies.numext-fixed-hash]
  git = "https://github.com/yangby-cryptape/rust-numext"
  branch = "optional-structs"
  default-features = false
  features = ["bits_256", "bits_512"]
  ```