### PR TITLE
feat: remove numerical methods for hashes

### DIFF
--- a/constructor/src/fixed_hash/core/builtin/as_primitive.rs
+++ b/constructor/src/fixed_hash/core/builtin/as_primitive.rs
@@ -122,16 +122,6 @@ impl HashConstructor {
                     Some(self._ushr(rhs))
                 }
             }
-            /// Checked negation. Computes `-self`, returning `None` unless `self == 0`.
-            /// Note that negating any positive integer will overflow.
-            #[inline]
-            pub fn checked_neg(&self) -> Option<Self> {
-                if self.is_zero() {
-                    Some(Self::zero())
-                } else {
-                    None
-                }
-            }
         );
         self.defun(part);
     }

--- a/constructor/src/fixed_hash/core/builtin/std_default.rs
+++ b/constructor/src/fixed_hash/core/builtin/std_default.rs
@@ -20,7 +20,7 @@ impl HashConstructor {
             impl ::std::default::Default for #name {
                 #[inline]
                 fn default() -> Self {
-                    Self::zero()
+                    Self::empty()
                 }
             }
         );

--- a/constructor/src/fixed_hash/core/internal/kernel.rs
+++ b/constructor/src/fixed_hash/core/internal/kernel.rs
@@ -34,14 +34,14 @@ impl HashConstructor {
         } else if self.info.bits_size < uc.info.bits_size {
             let this_bytes_size = &self.ts.unit_amount;
             quote!(
-                let mut ret = #that_name::zero();
+                let mut ret = #that_name::empty();
                 ret.mut_inner()[..#this_bytes_size].copy_from_slice(&self.inner()[..]);
                 (ret, false)
             )
         } else {
             let that_bytes_size = &uc.ts.unit_amount;
             quote!(
-                let mut ret = #that_name::zero();
+                let mut ret = #that_name::empty();
                 ret.mut_inner()
                     .copy_from_slice(&self.inner()[..#that_bytes_size]);
                 (ret, true)
@@ -96,11 +96,19 @@ impl HashConstructor {
                 Self::new([byte; #unit_amount])
             }
             /// Create a new fixed hash and all bits of it are zeros.
+            #[deprecated(
+                since = "0.1.5",
+                note = "Please use the empty function instead"
+            )]
             #[inline]
             pub const fn zero() -> Self {
                 Self::new([0; #unit_amount])
             }
             /// Test if all bits of a fixed hash are zero.
+            #[deprecated(
+                since = "0.1.5",
+                note = "Please use the is_empty function instead"
+            )]
             #[inline]
             pub fn is_zero(&self) -> bool {
                 let inner = self.inner();
@@ -112,8 +120,44 @@ impl HashConstructor {
                 true
             }
             /// Test if all bits of a fixed hash are one.
+            #[deprecated(
+                since = "0.1.5",
+                note = "Please use the is_full function instead"
+            )]
             #[inline]
             pub fn is_max(&self) -> bool {
+                let inner = self.inner();
+                #({
+                    if inner[#loop_unit_amount] != !0 {
+                        return false;
+                    }
+                })*
+                true
+            }
+            /// Create a new fixed hash and all bits of it are zero.
+            #[inline]
+            pub const fn empty() -> Self {
+                Self::new([0; #unit_amount])
+            }
+            /// Test if all bits of a fixed hash are zero.
+            #[inline]
+            pub fn is_empty(&self) -> bool {
+                let inner = self.inner();
+                #({
+                    if inner[#loop_unit_amount] != 0 {
+                        return false;
+                    }
+                })*
+                true
+            }
+            /// Create a new fixed hash and all bits of it are one.
+            #[inline]
+            pub const fn full() -> Self {
+                Self::new([!0; #unit_amount])
+            }
+            /// Test if all bits of a fixed hash are one.
+            #[inline]
+            pub fn is_full(&self) -> bool {
                 let inner = self.inner();
                 #({
                     if inner[#loop_unit_amount] != !0 {

--- a/constructor/src/fixed_hash/core/internal/private_ops.rs
+++ b/constructor/src/fixed_hash/core/internal/private_ops.rs
@@ -175,7 +175,7 @@ impl HashConstructor {
                     }
                     Self::new(ret)
                 } else {
-                    Self::zero()
+                    Self::empty()
                 }
             }
             #[inline]
@@ -206,7 +206,7 @@ impl HashConstructor {
                     }
                     Self::new(ret)
                 } else {
-                    Self::zero()
+                    Self::empty()
                 }
             }
         );

--- a/constructor/src/fixed_hash/core/internal/public_conv.rs
+++ b/constructor/src/fixed_hash/core/internal/public_conv.rs
@@ -59,7 +59,7 @@ impl HashConstructor {
                 if input.len() != #bytes_size {
                     Err(FromSliceError::InvalidLength(input.len()))?
                 } else {
-                    let mut ret = Self::zero();
+                    let mut ret = Self::empty();
                     ret.mut_inner()[..].copy_from_slice(input);
                     Ok(ret)
                 }
@@ -229,7 +229,7 @@ impl HashConstructor {
                 if len != #char_amount_max {
                     Err(FromStrError::InvalidLength(len))?;
                 }
-                let mut ret = Self::zero();
+                let mut ret = Self::empty();
                 {
                     let inner = ret.mut_inner();
                     #part_core
@@ -245,12 +245,12 @@ impl HashConstructor {
                     Err(FromStrError::InvalidLength(len))?;
                 } else if input.as_bytes()[0] == b'0' {
                     if len == 1 {
-                        return Ok(Self::zero());
+                        return Ok(Self::empty());
                     } else {
                         Err(FromStrError::InvalidCharacter { chr: b'0', idx: 0 })?;
                     }
                 }
-                let mut ret = Self::zero();
+                let mut ret = Self::empty();
                 let mut input_bytes = input.bytes();
                 let mut idx = 0;
                 let mut unit_idx = (#char_amount_max - len) / 2;

--- a/fixed-hash-tests/tests/const_fn.rs
+++ b/fixed-hash-tests/tests/const_fn.rs
@@ -1,6 +1,15 @@
+// Copyright 2018-2019 Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #![allow(dead_code)]
 
 use nfhash::H256;
 
-const ZERO: H256 = H256::zero();
-const MAX: H256 = H256::repeat_byte(1);
+const EMPTY: H256 = H256::empty();
+const FULL: H256 = H256::full();
+const ALL_BYTE_ARE_ONE: H256 = H256::repeat_byte(1);

--- a/fixed-hash-tests/tests/constructor.rs
+++ b/fixed-hash-tests/tests/constructor.rs
@@ -9,12 +9,14 @@
 use nfhash::{h128, h4096, H128, H4096};
 use std::str::FromStr;
 
-const H128_ZERO: H128 = h128!("0x0");
+const H128_EMPTY: H128 = h128!("0x0");
+const H128_FULL: H128 = h128!("0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff");
 const H64MAX: H4096 = h4096!("0x_ffff_ffff_ffff_ffff");
 
 #[test]
 fn constructor() {
-    assert_eq!(H128_ZERO, H128::zero());
+    assert_eq!(H128_EMPTY, H128::empty());
+    assert_eq!(H128_FULL, H128::full());
     {
         let x1 = h128!("0x123456789abcdef");
         let x2 = h128!("0x00000000000000000123456789abcdef");

--- a/fixed-hash-tests/tests/errors.rs
+++ b/fixed-hash-tests/tests/errors.rs
@@ -22,7 +22,7 @@ fn errors() {
     }
     {
         let mut input = [0u8; 17];
-        let hash = H128::zero();
+        let hash = H128::empty();
         let err = hash.into_slice(&mut input);
         if let Err(FixedHashError::IntoSlice(IntoSliceError::InvalidLength(_))) = err {
         } else {

--- a/fixed-hash-tests/tests/ext_rand.rs
+++ b/fixed-hash-tests/tests/ext_rand.rs
@@ -13,8 +13,10 @@ macro_rules! check_rand {
             let x = nfhash::$uint::thread_random();
             let y = nfhash::$uint::thread_random();
             // If this test is failed, please check if there is a bug or you are too luckly.
-            assert!(!x.is_zero());
-            assert!(!y.is_zero());
+            assert!(!x.is_empty());
+            assert!(!x.is_full());
+            assert!(!y.is_empty());
+            assert!(!y.is_full());
             assert!(x != y);
         }
     };


### PR DESCRIPTION
- chore: remove `checked_neg(..)` for hashes

  Hashes are not numbers. They are just neutral, neither negative nor positive.

  BREAKING CHANGE: remove `checked_neg(..)` for hashes

- refactor: add methods to replace numerical methods for hashes