### PR TITLE
fix(ci): fix format check; remove deprecated items; fix clippy::try-err warnings

### DIFF
--- a/constructor/src/fixed_hash/core/internal/private_ops.rs
+++ b/constructor/src/fixed_hash/core/internal/private_ops.rs
@@ -26,7 +26,7 @@ impl HashConstructor {
             quote!(
                 #[inline]
                 fn _bitand(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let inner = self.inner();
                     let rhs = rhs.inner();
                     #({
@@ -37,7 +37,7 @@ impl HashConstructor {
                 }
                 #[inline]
                 fn _bitor(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let inner = self.inner();
                     let rhs = rhs.inner();
                     #({
@@ -48,7 +48,7 @@ impl HashConstructor {
                 }
                 #[inline]
                 fn _bitxor(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let inner = self.inner();
                     let rhs = rhs.inner();
                     #({
@@ -62,7 +62,8 @@ impl HashConstructor {
             quote!(
                 #[inline]
                 fn _bitand(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type =
+                        unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let rhs = rhs.inner();
                     for (idx, lhs) in self.inner().iter().enumerate() {
                         ret[idx] = lhs & rhs[idx];
@@ -71,7 +72,8 @@ impl HashConstructor {
                 }
                 #[inline]
                 fn _bitor(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type =
+                        unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let rhs = rhs.inner();
                     for (idx, lhs) in self.inner().iter().enumerate() {
                         ret[idx] = lhs | rhs[idx];
@@ -80,7 +82,8 @@ impl HashConstructor {
                 }
                 #[inline]
                 fn _bitxor(&self, rhs: &Self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type =
+                        unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let rhs = rhs.inner();
                     for (idx, lhs) in self.inner().iter().enumerate() {
                         ret[idx] = lhs ^ rhs[idx];
@@ -99,7 +102,7 @@ impl HashConstructor {
             quote!(
                 #[inline]
                 fn _not(&self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let inner = self.inner();
                     #({
                         let idx = #loop_unit_amount;
@@ -112,7 +115,8 @@ impl HashConstructor {
             quote!(
                 #[inline]
                 fn _not(&self) -> Self {
-                    let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                    let mut ret: #inner_type =
+                        unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                     let inner = self.inner();
                     for (idx, val) in self.inner().iter().enumerate() {
                         ret[idx] = !val;

--- a/constructor/src/fixed_uint/core/internal/private_ops.rs
+++ b/constructor/src/fixed_uint/core/internal/private_ops.rs
@@ -201,7 +201,8 @@ impl UintConstructor {
             fn _add(&self, other: &Self) -> (Self, bool) {
                 let lhs = self.inner();
                 let rhs = other.inner();
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type =
+                    unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let ret_ptr = &mut ret as *mut #inner_type as *mut #unit_suffix;
                 let mut of = false;
                 #loop_part;
@@ -242,7 +243,8 @@ impl UintConstructor {
             fn _sub(&self, other: &Self) -> (Self, bool) {
                 let lhs = self.inner();
                 let rhs = other.inner();
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type =
+                    unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let ret_ptr = &mut ret as *mut #inner_type as *mut #unit_suffix;
                 let mut of = false;
                 #loop_part;
@@ -755,7 +757,7 @@ impl UintConstructor {
         let part = quote!(
             #[inline]
             fn _bitand(&self, rhs: &Self) -> Self {
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let inner = self.inner();
                 let rhs = rhs.inner();
                 #({
@@ -766,7 +768,7 @@ impl UintConstructor {
             }
             #[inline]
             fn _bitor(&self, rhs: &Self) -> Self {
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let inner = self.inner();
                 let rhs = rhs.inner();
                 #({
@@ -777,7 +779,7 @@ impl UintConstructor {
             }
             #[inline]
             fn _bitxor(&self, rhs: &Self) -> Self {
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let inner = self.inner();
                 let rhs = rhs.inner();
                 #({
@@ -796,7 +798,7 @@ impl UintConstructor {
         let part = quote!(
             #[inline]
             fn _not(&self) -> Self {
-                let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
+                let mut ret: #inner_type = unsafe { ::std::mem::MaybeUninit::uninit().assume_init() };
                 let inner = self.inner();
                 #({
                     let idx = #loop_unit_amount;


### PR DESCRIPTION
Since CI didn't run since `rust-toolchain v1.35.0`, there are lots warnings.