### PR TITLE
chore(deps): bump almost all dependencies to latest version

### DIFF
--- a/constructor/Cargo.toml
+++ b/constructor/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["algorithms", "data-structures"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-syn = { version = "~0.15", features = ["extra-traits"] }
-quote = "~0.6"
-proc-macro2 = "~0.4"
+syn = { version = "~1.0", features = ["extra-traits"] }
+quote = "~1.0"
+proc-macro2 = "~1.0"
 
 [lib]
 proc-macro = true

--- a/constructor/src/fixed_hash/core/extension/serde.rs
+++ b/constructor/src/fixed_hash/core/extension/serde.rs
@@ -32,7 +32,7 @@ impl HashConstructor {
                     let mut dst = [0u8; #bytes_size * 2 + 2];
                     dst[0] = b'0';
                     dst[1] = b'x';
-                    faster_hex::hex_to(bytes, &mut dst[2..])
+                    faster_hex::hex_encode(bytes, &mut dst[2..])
                         .map_err(|e| serde::ser::Error::custom(&format!("{}", e)))?;
                     serializer.serialize_str(unsafe { ::std::str::from_utf8_unchecked(&dst) })
                 }

--- a/constructor/src/utils.rs
+++ b/constructor/src/utils.rs
@@ -12,7 +12,7 @@ use syn;
 
 macro_rules! parse_attr_with_check {
     (Int, $key:ident, $input:ident, $output:ident) => {
-        $output.$key = $input.value();
+        $output.$key = $input.base10_digits().parse().unwrap();
     };
     (Bool, $key:ident, $input:ident, $output:ident) => {
         $output.$key = $input.value;
@@ -44,7 +44,7 @@ macro_rules! parse_attr_with_check {
 
 /// Get a nonnegative integer literal without type.
 pub fn pure_uint_to_ts(val: u64) -> TokenStream {
-    syn::LitInt::new(val, syn::IntSuffix::None, Span::call_site()).into_token_stream()
+    syn::LitInt::new(&val.to_string(), Span::call_site()).into_token_stream()
 }
 
 /// Get a built-in nonnegative integer type.

--- a/fixed-hash-tests/Cargo.toml
+++ b/fixed-hash-tests/Cargo.toml
@@ -9,11 +9,11 @@ autobenches = false
 [dependencies]
 nfhash = { package = "numext-fixed-hash", version = "~0.1.4", path = "../fixed-hash", features = ["support_all"] }
 etypes = { package = "ethereum-types", version = "~0.4" }
-proptest = "~0.8"
-rand = "~0.5"
+proptest = "~0.9"
+rand = "~0.7"
 
 [dev-dependencies]
-criterion = "~0.2"
+criterion = "~0.3"
 serde_json = "~1.0"
 
 [[bench]]

--- a/fixed-hash-tests/tests/ext_serde.rs
+++ b/fixed-hash-tests/tests/ext_serde.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nfhash_tests::props;
-use proptest::{prelude::any, proptest, proptest_helper};
+use proptest::{prelude::any, proptest};
 
 proptest! {
     #[test]

--- a/fixed-hash-tests/tests/int_conv_slice.rs
+++ b/fixed-hash-tests/tests/int_conv_slice.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nfhash_tests::props;
-use proptest::{prelude::any, proptest, proptest_helper};
+use proptest::{prelude::any, proptest};
 
 proptest! {
     #[test]

--- a/fixed-hash/core/Cargo.toml
+++ b/fixed-hash/core/Cargo.toml
@@ -14,10 +14,10 @@ license = "Apache-2.0 OR MIT"
 constructor = { package = "numext-constructor", version = "=0.1.4", path = "../../constructor" }
 nfuint = { package = "numext-fixed-uint", version = "=0.1.4", path = "../../fixed-uint" }
 failure = "~0.1"
-rand = { version = "~0.5", optional = true }
+rand = { version = "~0.7", optional = true }
 heapsize = { version = "~0.4", optional = true }
 serde = { version = "~1.0", optional = true }
-faster-hex = { version = "~0.1", optional = true }
+faster-hex = { version = "~0.4", optional = true }
 
 [features]
 default = ["bits_all"]

--- a/fixed-hash/hack/Cargo.toml
+++ b/fixed-hash/hack/Cargo.toml
@@ -16,9 +16,9 @@ proc-macro = true
 [dependencies]
 nfhash-core = { package = "numext-fixed-hash-core", version = "=0.1.4", path = "../core" }
 proc-macro-hack = "~0.5"
-syn = { version = "~0.15", features = ["extra-traits"] }
-quote = "~0.6"
-proc-macro2 = "~0.4"
+syn = { version = "~1.0", features = ["extra-traits"] }
+quote = "~1.0"
+proc-macro2 = "~1.0"
 
 [features]
 default = ["bits_all"]

--- a/fixed-uint-tests/Cargo.toml
+++ b/fixed-uint-tests/Cargo.toml
@@ -11,11 +11,11 @@ nfuint = { package = "numext-fixed-uint", version = "~0.1.4", path = "../fixed-u
 etypes = { package = "ethereum-types", version = "~0.4" }
 num-bigint = "~0.2"
 num-integer = "~0.1"
-proptest = "~0.8"
-rand = "~0.5"
+proptest = "~0.9"
+rand = "~0.7"
 
 [dev-dependencies]
-criterion = "~0.2"
+criterion = "~0.3"
 serde_json = "~1.0"
 
 [[bench]]

--- a/fixed-uint-tests/tests/ext_serde.rs
+++ b/fixed-uint-tests/tests/ext_serde.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nfuint_tests::props;
-use proptest::{prelude::any, proptest, proptest_helper};
+use proptest::{prelude::any, proptest};
 
 proptest! {
     #[test]

--- a/fixed-uint-tests/tests/int_conv_slice.rs
+++ b/fixed-uint-tests/tests/int_conv_slice.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nfuint_tests::props;
-use proptest::{prelude::any, proptest, proptest_helper};
+use proptest::{prelude::any, proptest};
 
 proptest! {
     #[test]

--- a/fixed-uint-tests/tests/int_math.rs
+++ b/fixed-uint-tests/tests/int_math.rs
@@ -10,7 +10,7 @@ use nfuint::U256;
 use nfuint_tests::props;
 use num_bigint::BigUint;
 use num_integer::Integer;
-use proptest::{prelude::any_with, proptest, proptest_helper};
+use proptest::{prelude::any_with, proptest};
 
 proptest! {
     #[test]

--- a/fixed-uint-tests/tests/prim_bytes.rs
+++ b/fixed-uint-tests/tests/prim_bytes.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use nfuint_tests::props;
-use proptest::{prelude::any, proptest, proptest_helper};
+use proptest::{prelude::any, proptest};
 
 proptest! {
     #[test]

--- a/fixed-uint-tests/tests/std_cmp.rs
+++ b/fixed-uint-tests/tests/std_cmp.rs
@@ -9,7 +9,7 @@
 use nfuint_tests::props;
 use proptest::{
     prelude::{any, any_with},
-    proptest, proptest_helper,
+    proptest,
 };
 
 proptest! {

--- a/fixed-uint/core/Cargo.toml
+++ b/fixed-uint/core/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 constructor = { package = "numext-constructor", version = "=0.1.4", path = "../../constructor" }
 failure = "~0.1"
-rand = { version = "~0.5", optional = true }
+rand = { version = "~0.7", optional = true }
 heapsize = { version = "~0.4", optional = true }
 serde = { version = "~1.0", optional = true }
 

--- a/fixed-uint/hack/Cargo.toml
+++ b/fixed-uint/hack/Cargo.toml
@@ -16,9 +16,9 @@ proc-macro = true
 [dependencies]
 nfuint-core = { package = "numext-fixed-uint-core", version = "=0.1.4", path = "../core" }
 proc-macro-hack = "~0.5"
-syn = { version = "~0.15", features = ["extra-traits"] }
-quote = "~0.6"
-proc-macro2 = "~0.4"
+syn = { version = "~1.0", features = ["extra-traits"] }
+quote = "~1.0"
+proc-macro2 = "~1.0"
 
 [features]
 default = ["bits_all"]


### PR DESCRIPTION
Upgrade:
- `syn ~0.15 -> ~1.0`
- `quote ~0.6 -> ~1.0`
- `proc-macro2 ~0.4 -> ~1.0`
- `faster-hex ~0.1 -> ~0.4`
- `rand ~0.5 -> ~0.7`
- `proptest ~0.8 -> ~0.9`
- `criterion ~0.2 -> ~0.3`

Hold:
- `ethereum-types ~0.4` (latest version is `0.8.0`)
  Since a new benchmark is required, this update will be in a separate PR.