### PR TITLE
fix: avoid trigger a rustc bug which causes errors when build with target wasm32-unknown-unknown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ jobs:
       name: Minimum
       rust: 1.45.0
     - stage: Test
+      name: Wasm32
+      install: rustup target add wasm32-unknown-unknown
+      script: cd tests/numext-build && cargo build --target=wasm32-unknown-unknown
+    - stage: Test
       os: osx
     - stage: Test
       os: windows

--- a/fixed-hash/core/src/lib.rs
+++ b/fixed-hash/core/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! [numext-fixed-hash]: https://docs.rs/numext-fixed-hash
 
+extern crate constructor;
+
 use thiserror::Error;
 
 #[macro_use]

--- a/fixed-hash/hack/src/lib.rs
+++ b/fixed-hash/hack/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! [numext-fixed-hash]: https://docs.rs/numext-fixed-hash
 
+extern crate nfhash_core;
+
 extern crate proc_macro;
 
 use quote::quote;

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -35,6 +35,9 @@
 //! }
 //! ```
 
+extern crate nfhash_core;
+extern crate nfhash_hack;
+
 pub use nfhash_core::prelude;
 pub use nfhash_core::{FixedHashError, FromSliceError, FromStrError, IntoSliceError};
 

--- a/fixed-uint/core/src/lib.rs
+++ b/fixed-uint/core/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! [numext-fixed-uint]: https://docs.rs/numext-fixed-uint
 
+extern crate constructor;
+
 use thiserror::Error;
 
 constructor::construct_fixed_uints!(

--- a/fixed-uint/hack/src/lib.rs
+++ b/fixed-uint/hack/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! [numext-fixed-uint]: https://docs.rs/numext-fixed-uint
 
+extern crate nfuint_core;
+
 extern crate proc_macro;
 
 use quote::quote;

--- a/fixed-uint/src/lib.rs
+++ b/fixed-uint/src/lib.rs
@@ -40,6 +40,9 @@
 //! }
 //! ```
 
+extern crate nfuint_core;
+extern crate nfuint_hack;
+
 pub use nfuint_core::prelude;
 pub use nfuint_core::{FixedUintError, FromSliceError, FromStrError, IntoSliceError};
 

--- a/tests/numext-build/Cargo.toml
+++ b/tests/numext-build/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "numext-build"
+version = "0.1.5"
+authors = ["Cryptape Technologies <contact@cryptape.com>"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+nfuint = { package = "numext-fixed-uint", version = "~0.1.5", path = "../../fixed-uint", features = ["support_all"] }
+nfhash = { package = "numext-fixed-hash", version = "~0.1.5", path = "../../fixed-hash", features = ["support_all"] }
+
+[workspace]
+members = ["."]

--- a/tests/numext-build/src/lib.rs
+++ b/tests/numext-build/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright 2018-2020 Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate nfhash;
+extern crate nfuint;


### PR DESCRIPTION
Avoid trigger [a rustc bug](https://github.com/rust-lang/rust/issues/75533) which causes errors when build with target `wasm32-unknown-unknown`.